### PR TITLE
feat(policy): allow skill scripts without permission prompt

### DIFF
--- a/.gemini/policies/skill-permissions.toml
+++ b/.gemini/policies/skill-permissions.toml
@@ -1,0 +1,14 @@
+[[rule]]
+toolName = "run_shell_command"
+# This pattern matches any shell command that calls a script within the .gemini/skills directory
+# It handles both absolute and relative paths, and allows for script arguments.
+commandPattern = '.*\.gemini/skills/.*/scripts/.*\.sh.*'
+decision = "allow"
+priority = 100
+
+[[rule]]
+toolName = "run_shell_command"
+# A fallback for scripts called without the .gemini/skills prefix if they are in a scripts/ folder
+commandPattern = '^scripts/.*/.*\.sh.*'
+decision = "allow"
+priority = 90


### PR DESCRIPTION
This PR adds a general policy to .gemini/policies/skill-permissions.toml that automatically permits the execution of any bash script within the .gemini/skills/ directory structure. This ensures a smoother workflow for both current and future skills.