### PR TITLE
Rebrand project from qk to sk

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,8 +5,8 @@ SuperKind is a Go-based, plugin-driven wrapper for [kind](https://kind.sigs.k8s.
 ## 🏗️ Core Architecture
 
 - **CLI Layer**: 
-    - `superkind` (alias: `qk`): A Go binary built with Cobra. Manages the lifecycle of SuperKind clusters (prefixed with `qk-`).
-    - **Native Plugins**: Integrated Go logic for modular extensions (ArgoCD, OTEL, KEDA, etc.), managed via `qk plugin`.
+    - `superkind` (alias: `sk`): A Go binary built with Cobra. Manages the lifecycle of SuperKind clusters (prefixed with `sk-`).
+    - **Native Plugins**: Integrated Go logic for modular extensions (ArgoCD, OTEL, KEDA, etc.), managed via `sk plugin`.
 - **Infrastructure Layer**:
     - **Kind SDK**: Orchestrates the underlying Kubernetes engine programmatically.
     - **Docker SDK**: Manages the local [Zot](https://zotregistry.dev/) registry (`localhost:5001`) and pull-through caching (`registry:2` instances).
@@ -14,7 +14,7 @@ SuperKind is a Go-based, plugin-driven wrapper for [kind](https://kind.sigs.k8s.
 - **Service Layer (Helm SDK)**:
     - **Ingress-NGINX**: Programmatically installed via Helm Go SDK.
     - **Kube-Prometheus-Stack**: Installed by default for observability.
-    - **Cert-Manager**: Manages internal TLS using the `quick-kind-ca` ClusterIssuer.
+    - **Cert-Manager**: Manages internal TLS using the `superkind-ca` ClusterIssuer.
 
 ## 🚀 Key Workflows
 
@@ -23,20 +23,20 @@ The project uses a `Makefile` for building and installation.
 ```bash
 make install
 ```
-*This builds the binary to `bin/superkind`, copies it to `~/.local/bin`, and sets up shell aliases in `~/.bashrc.d/superkind.sh`.*
+*This builds the binary to `bin/superkind`, copies it to `~/.local/bin`, and sets up the shell environment in `~/.bashrc.d/superkind.sh`.*
 
 ### 2. Cluster Management
-- **Create/Update**: `qk up` (creates `qk-quick-cluster`) or `qk up [name]`.
-- **Status**: `qk status [name]`.
-- **List**: `qk list` (lists only `qk-` prefixed clusters).
-- **Delete**: `qk delete [name]`.
+- **Create/Update**: `sk up` (creates `sk-cluster`) or `sk up [name]`.
+- **Status**: `sk status [name]`.
+- **List**: `sk list` (lists only `sk-` prefixed clusters).
+- **Delete**: `sk delete [name]`.
 
 ### 3. Plugin Management
 Plugins are implemented as Go structs satisfying the `Plugin` interface.
-- **List plugins**: `qk plugin` (no args).
-- **Install**: `qk plugin <name> install`.
-- **Status**: `qk plugin <name> status`.
-- **Uninstall**: `qk plugin <name> uninstall`.
+- **List plugins**: `sk plugin` (no args).
+- **Install**: `sk plugin <name> install`.
+- **Status**: `sk plugin <name> status`.
+- **Uninstall**: `sk plugin <name> uninstall`.
 
 ## 🛠️ Development Conventions
 
@@ -46,7 +46,7 @@ Plugins are implemented as Go structs satisfying the `Plugin` interface.
     - Every new feature or plugin MUST include unit tests in the same package.
     - Use `go test ./...` to verify the entire project.
 - **Registry Usage**: Always prefer the local Zot registry (`localhost:5001`) or the pull-through caches for speed and to avoid throttling.
-- **TLS**: Use the `quick-kind-ca` ClusterIssuer for all internal service certificates.
+- **TLS**: Use the `superkind-ca` ClusterIssuer for all internal service certificates.
 
 ## 📁 Key Directories & Files
 
@@ -61,4 +61,4 @@ Plugins are implemented as Go structs satisfying the `Plugin` interface.
 - **Go Version**: Requires Go 1.24+ for building.
 - **Docker**: Requires the Docker daemon to be running and the `docker` CLI or alias to be present for Kind compatibility.
 - **Shell Sourcing**: After `make install`, ensure `~/.bashrc` sources `~/.bashrc.d/*.sh`.
-- **Naming**: Only clusters starting with `qk-` are managed by SuperKind tools.
+- **Naming**: Only clusters starting with `sk-` are managed by SuperKind tools.

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ install: build
 	@echo "⚙️  Installing $(BINARY_NAME) to $(INSTALL_PATH)..."
 	cp $(BIN_DIR)/$(BINARY_NAME) $(INSTALL_PATH)
 	chmod +x $(INSTALL_PATH)
+	ln -sf $(BINARY_NAME) $(INSTALL_DIR)/sk
 
 	@echo "⚙️  Copying assets..."
 	cp -f src/fallback.yaml $(KIND_DIR)/
@@ -41,11 +42,8 @@ install: build
 		cp -r src/otel-plugin-extras $(KIND_DIR)/otel-plugin-extras; \
 	fi
 
-	@echo "🔗 Setting up aliases in $(BASHRC_D)/superkind.sh..."
-	@echo "alias qk='superkind'" > $(BASHRC_D)/superkind.sh
-	@echo "alias quick-kind='superkind'" >> $(BASHRC_D)/superkind.sh
-	@echo "alias kind-plugin='superkind plugin'" >> $(BASHRC_D)/superkind.sh
-	@echo "export PATH=\"\$$PATH:$(INSTALL_DIR)\"" >> $(BASHRC_D)/superkind.sh
+	@echo "🔗 Setting up PATH in $(BASHRC_D)/superkind.sh..."
+	@echo "export PATH=\"\$$PATH:$(INSTALL_DIR)\"" > $(BASHRC_D)/superkind.sh
 
 	@echo "✅ SuperKind installed successfully."
 	@echo "💡 Make sure your ~/.bashrc sources files in $(BASHRC_D):"
@@ -55,6 +53,7 @@ install: build
 uninstall:
 	@echo "🧹 Removing SuperKind files..."
 	rm -f $(INSTALL_PATH)
+	rm -f $(INSTALL_DIR)/sk
 	rm -f $(BASHRC_D)/superkind.sh
 	rm -rf $(KIND_PLUGIN_DIR)
 	@echo "✅ SuperKind uninstalled."

--- a/README.md
+++ b/README.md
@@ -47,39 +47,41 @@ cd SuperKind
 make install
 ```
 
-This builds the `superkind` binary, installs it to `~/.local/bin`, and sets up your shell environment (alias: `qk`).
+This builds the `superkind` binary, installs it to `~/.local/bin`, and sets up your shell environment (alias: `sk`).
 
 ---
 
 ## ⚙️ Commands Overview
 
-| Command                | Description                                                        |
-| ---------------------- | ------------------------------------------------------------------ |
-| `qk`                   | Show help or status of the default cluster                         |
-| `qk up`                | Create or update the default cluster (`qk-quick-cluster`)          |
-| `qk up [name]`         | Create a new cluster named `qk-[name]`                             |
-| `qk status [name]`     | Show status of `qk-[name]`                                         |
-| `qk delete [name]`     | Delete `qk-[name]`                                                 |
-| `qk list`              | List all SuperKind clusters (prefixed with `qk-`)                  |
-| `qk plugin`            | Manage native Go plugins (install, status, uninstall)              |
+You can use either `superkind` or the shorter `sk` alias.
+
+| Command                        | Description                                                        |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `sk`                           | Show help or status of the default cluster                         |
+| `sk up`                       | Create or update the default cluster (`sk-cluster`)                |
+| `sk up [name]`                | Create a new cluster named `sk-[name]`                             |
+| `sk status [name]`            | Show status of `sk-[name]`                                         |
+| `sk delete [name]`            | Delete `sk-[name]`                                                 |
+| `sk list`                     | List all SuperKind clusters (prefixed with `sk-`)                  |
+| `sk plugin`                   | Manage native Go plugins (install, status, uninstall)              |
 
 ### 🧩 Example session
 
 ```bash
-# Create a new cluster named qk-dev
-qk up dev
+# Create a new cluster named sk-dev
+sk up dev
 
 # Install ArgoCD via native Go plugin
-qk plugin argocd install
+sk plugin argocd install
 
 # Check cluster status
-qk status dev
+sk status dev
 
 # List all SuperKind clusters
-qk list
+sk list
 
 # Delete the cluster
-qk delete dev
+sk delete dev
 ```
 
 ---
@@ -117,4 +119,4 @@ Everything is modular, idempotent, and executed via Go code.
 
 ## ✅ Summary
 
-Run `qk up` to spin up clusters, `qk list` to list them, and `qk delete` to clean them up — all locally, fast, and fully automated.
+Run `sk up` to spin up clusters, `sk list` to list them, and `sk delete` to clean them up — all locally, fast, and fully automated.

--- a/cmd/superkind/delete.go
+++ b/cmd/superkind/delete.go
@@ -11,7 +11,7 @@ import (
 
 var deleteCmd = &cobra.Command{
 	Use:     "delete [name]",
-	Aliases: []string{"teardown"},
+	Aliases: []string{"teardown", "down"},
 	Short:   "Delete a SuperKind cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := config.DefaultConfig()

--- a/cmd/superkind/main.go
+++ b/cmd/superkind/main.go
@@ -10,7 +10,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "superkind",
 	Short: "SuperKind is a super-charged Kind wrapper with local registries and CA.",
-	Long: `SuperKind (qk) is an opinionated, plugin-based wrapper for kind (Kubernetes in Docker). 
+	Long: `SuperKind is an opinionated, plugin-based wrapper for kind (Kubernetes in Docker). 
 It automates the setup of essential infrastructure like Ingress, Cert-Manager, Registries, and Caching.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Default behavior: show help or status

--- a/cmd/superkind/up.go
+++ b/cmd/superkind/up.go
@@ -81,6 +81,6 @@ var upCmd = &cobra.Command{
 }
 
 func init() {
-	upCmd.Flags().StringP("name", "n", "", "Cluster name (will be prefixed with qk-)")
+	upCmd.Flags().StringP("name", "n", "", "Cluster name (will be prefixed with sk-)")
 	rootCmd.AddCommand(upCmd)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,24 +30,24 @@ type Config struct {
 
 func DefaultConfig() *Config {
 	home, _ := os.UserHomeDir()
-	caDir := filepath.Join(home, ".local/share/quick-kind/ca")
+	caDir := filepath.Join(home, ".local/share/superkind/ca")
 
 	return &Config{
-		NamePrefix:            "qk-",
-		DefaultBaseName:       "quick-cluster",
+		NamePrefix:            "sk-",
+		DefaultBaseName:       "cluster",
 		LocalRegistryName:     "local-registry",
 		LocalRegistryHostPort: "5001",
 		DockerHubCacheName:    "dockerhub-proxy-cache",
 		QuayCacheName:         "quay-proxy-cache",
 		GHCRCacheName:         "ghcr-proxy-cache",
 		MCRCacheName:          "mcr-proxy-cache",
-		CASecretName:          "quick-kind-ca",
-		CAIssuerName:          "quick-kind-ca",
+		CASecretName:          "superkind-ca",
+		CAIssuerName:          "superkind-ca",
 		CADir:                 caDir,
 		CAKey:                 filepath.Join(caDir, "rootCA.key"),
 		CACrt:                 filepath.Join(caDir, "rootCA.crt"),
-		CACN:                  "Quick Kind Local CA",
-		CAOrg:                 "Quick Kind",
+		CACN:                  "SuperKind Local CA",
+		CAOrg:                 "SuperKind",
 		CAOU:                  "Dev",
 		CADays:                3650,
 		PluginDir:             filepath.Join(home, ".kind/plugin"),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,12 +8,12 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 
-	if cfg.NamePrefix != "qk-" {
-		t.Errorf("Expected NamePrefix qk-, got %s", cfg.NamePrefix)
+	if cfg.NamePrefix != "sk-" {
+		t.Errorf("Expected NamePrefix sk-, got %s", cfg.NamePrefix)
 	}
 
-	if cfg.DefaultBaseName != "quick-cluster" {
-		t.Errorf("Expected DefaultBaseName quick-cluster, got %s", cfg.DefaultBaseName)
+	if cfg.DefaultBaseName != "cluster" {
+		t.Errorf("Expected DefaultBaseName cluster, got %s", cfg.DefaultBaseName)
 	}
 
 	if cfg.LocalRegistryHostPort != "5001" {
@@ -23,7 +23,7 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestConfigToEngineConfigs(t *testing.T) {
 	cfg := DefaultConfig()
-	clusterName := "qk-test"
+	clusterName := "sk-test"
 
 	pkiCfg := cfg.ToPKIConfig()
 	if !strings.HasSuffix(pkiCfg.CAKey, "rootCA.key") {

--- a/pkg/engine/pki.go
+++ b/pkg/engine/pki.go
@@ -98,13 +98,13 @@ func EnsureLocalCA(cfg PKIConfig) error {
 
 func DefaultPKIConfig() PKIConfig {
 	home, _ := os.UserHomeDir()
-	caDir := filepath.Join(home, ".local/share/quick-kind/ca")
+	caDir := filepath.Join(home, ".local/share/superkind/ca")
 	return PKIConfig{
 		CADir:  caDir,
 		CAKey:  filepath.Join(caDir, "rootCA.key"),
 		CACrt:  filepath.Join(caDir, "rootCA.crt"),
-		CACN:   "Quick Kind Local CA",
-		CAOrg:  "Quick Kind",
+		CACN:   "SuperKind Local CA",
+		CAOrg:  "SuperKind",
 		CAOU:   "Dev",
 		CADays: 3650,
 	}

--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,7 @@ metadata:
   name: myapp
   namespace: default
   annotations:
-    cert-manager.io/cluster-issuer: "quick-kind-ca"
+    cert-manager.io/cluster-issuer: "superkind-ca"
 spec:
   ingressClassName: nginx
   rules:
@@ -70,7 +70,7 @@ spec:
     - app.localhost
     secretName: app-localhost-tls</code></pre>
                 <p class="text-xs text-[#6C7B7F] mt-3">TLS is automatically signed by your local
-                    <code>quick-kind-ca</code> ClusterIssuer.</p>
+                    <code>superkind-ca</code> ClusterIssuer.</p>
             </div>
         </section>
 
@@ -83,7 +83,7 @@ spec:
             </p>
             <p class="text-sm text-[#4A585C] mb-4">
                 The Root CA file is located at:<br>
-                <code class="bg-[#F2F7F7] border border-[#D5E1E1] rounded px-1 py-0.5">/home/&lt;your-username&gt;/.local/share/quick-kind/ca/rootCA.crt</code>
+                <code class="bg-[#F2F7F7] border border-[#D5E1E1] rounded px-1 py-0.5">/home/&lt;your-username&gt;/.local/share/superkind/ca/rootCA.crt</code>
 
             </p>
 
@@ -93,7 +93,7 @@ spec:
                     1. Open your browser’s settings.<br>
                     2. Search for “Certificates” or “Manage Certificates”.<br>
                     3. Under “Authorities” or “Trusted Root Certificates”, click **Import**.<br>
-                    4. Select your <code>rootCA.crt</code> file from <code>~/.local/share/quick-kind/ca/</code>.<br>
+                    4. Select your <code>rootCA.crt</code> file from <code>~/.local/share/superkind/ca/</code>.<br>
                     5. Confirm trust for websites, then close and reopen your browser.
                 </p>
             </div>
@@ -116,21 +116,21 @@ spec:
             <div class="mt-4">
                 <h3 class="font-semibold text-sm text-[#0F6A6D] mb-1">Common Commands:</h3>
                 <pre class="bg-[#F2F7F7] border border-[#D5E1E1] rounded-lg p-3 text-sm overflow-auto"><code># Create or start the cluster
-qk up
+sk up
 
 # Show cluster status
-qk status
+sk status
 
 # Delete cluster
-qk --teardown
+sk delete
 
 # List all SuperKind clusters
-qk --list</code></pre>
+sk list</code></pre>
             </div>
 
             <div class="mt-4">
                 <h3 class="font-semibold text-sm text-[#0F6A6D] mb-1">Available Plugins:</h3>
-                <pre class="bg-[#F2F7F7] border border-[#D5E1E1] rounded-lg p-3 text-sm overflow-auto"><code>Usage: kind-plugin &lt;plugin&gt; [command] [args...]
+                <pre class="bg-[#F2F7F7] border border-[#D5E1E1] rounded-lg p-3 text-sm overflow-auto"><code>Usage: sk plugin &lt;plugin&gt; [command] [args...]
 
 Available plugins:
   - epinio
@@ -142,8 +142,8 @@ Available plugins:
   - velero
 
 Examples:
-  kind-plugin epinio install
-  kind-plugin olm status</code></pre>
+  sk plugin epinio install
+  sk plugin olm status</code></pre>
             </div>
         </section>
 

--- a/src/otel-plugin-extras/Taskfile.yaml
+++ b/src/otel-plugin-extras/Taskfile.yaml
@@ -38,7 +38,7 @@ tasks:
     desc: Load the SimpleApi container image into the local kind cluster
     summary: Loads the SimpleApi container image into kind
     env:
-      KIND_CLUSTER_NAME: qk-quick-cluster
+      KIND_CLUSTER_NAME: sk-cluster
     cmds:
       - kind load docker-image ${CONTAINER_REPOSITORY}:${CONTAINER_IMAGE_TAG} --name ${KIND_CLUSTER_NAME}
 
@@ -47,6 +47,6 @@ tasks:
     desc: Deploy the SimpleApi application to the local kind cluster
     summary: Applies the Kubernetes manifests to the kind cluster
     env:
-      KUBECTL_CONTEXT: kind-qk-quick-cluster
+      KUBECTL_CONTEXT: kind-sk-cluster
     cmds:
       - kubectl apply -k . --context ${KUBECTL_CONTEXT}


### PR DESCRIPTION
This PR rebrands the project from 'qk' to 'sk', updates default cluster names, and replaces shell aliases with a symlink in the Makefile for better compatibility. Key changes include updating the README, configuration defaults, and CLI help text.