### PR TITLE
feat: add VPA (Vertical Pod Autoscaler) plugin

### DIFF
--- a/pkg/engine/k8s.go
+++ b/pkg/engine/k8s.go
@@ -194,6 +194,23 @@ func RunHelmInstall(releaseName, chartName, repoURL, version string, namespace s
 	return err
 }
 
+func RunHelmUninstall(releaseName, namespace string) error {
+	settings := cli.New()
+
+	actionConfig := new(action.Configuration)
+	if err := actionConfig.Init(settings.RESTClientGetter(), namespace, os.Getenv("HELM_DRIVER"), log.Printf); err != nil {
+		return err
+	}
+
+	client := action.NewUninstall(actionConfig)
+	fmt.Printf("🧹 uninstalling helm release %s in %s...\n", releaseName, namespace)
+	_, err := client.Run(releaseName)
+	if err != nil && err != driver.ErrReleaseNotFound {
+		return err
+	}
+	return nil
+}
+
 func EnsureCASecretAndIssuer(cfg K8sConfig) error {
 	clientset, dynClient, err := GetClients()
 	if err != nil {

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -74,6 +74,7 @@ func DefaultPluginManager() *PluginManager {
 	m.RegisterGoPlugin(NewEpinioPlugin())
 	m.RegisterGoPlugin(NewAWXPlugin())
 	m.RegisterGoPlugin(NewGatewayAPIPlugin())
+	m.RegisterGoPlugin(NewVPAPlugin())
 	// We will register other plugins here as we implement them
 	return m
 }

--- a/pkg/plugin/vpa.go
+++ b/pkg/plugin/vpa.go
@@ -1,0 +1,49 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/josephaw1022/superkind/pkg/engine"
+)
+
+type VPAPlugin struct{}
+
+func NewVPAPlugin() *VPAPlugin {
+	return &VPAPlugin{}
+}
+
+func (p *VPAPlugin) Name() string {
+	return "vpa"
+}
+
+func (p *VPAPlugin) Install() error {
+	fmt.Println("📈 Installing Vertical Pod Autoscaler (VPA)...")
+	values := map[string]interface{}{}
+
+	return engine.RunHelmInstall(
+		"vpa",
+		"vpa",
+		"https://kubernetes.github.io/autoscaler",
+		"0.8.0",
+		"kube-system",
+		values,
+	)
+}
+
+func (p *VPAPlugin) Status() error {
+	fmt.Println("🔎 Checking VPA status...")
+	// We can add more detailed check here later
+	return nil
+}
+
+func (p *VPAPlugin) Uninstall() error {
+	return engine.RunHelmUninstall("vpa", "kube-system")
+}
+
+func (p *VPAPlugin) Help() string {
+	return `vpa plugin (Go)
+  install     Install Vertical Pod Autoscaler
+  status      Show status
+  uninstall   Remove the Helm release
+  help        Show this help`
+}

--- a/pkg/plugin/vpa_test.go
+++ b/pkg/plugin/vpa_test.go
@@ -1,0 +1,15 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func TestVPAPlugin_Metadata(t *testing.T) {
+	p := NewVPAPlugin()
+	if p.Name() != "vpa" {
+		t.Errorf("Expected name vpa, got %s", p.Name())
+	}
+	if p.Help() == "" {
+		t.Error("Help message should not be empty")
+	}
+}


### PR DESCRIPTION
This PR adds a native Go plugin for Vertical Pod Autoscaler (VPA).

### Changes:
- Added `RunHelmUninstall` to the `engine` package to support removing Helm releases programmatically.
- Implemented the `VPAPlugin` in `pkg/plugin/vpa.go` using the Helm Go SDK.
- Registered the `vpa` plugin in `pkg/plugin/manager.go`.
- Added unit tests for the VPA plugin metadata in `pkg/plugin/vpa_test.go`.

Closes #17